### PR TITLE
RFC: fixes for recent kernels

### DIFF
--- a/ap.c
+++ b/ap.c
@@ -914,10 +914,15 @@ void xradio_multicast_stop_work(struct work_struct *work)
 	}
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+void xradio_mcast_timeout(struct timer_list *t)
+{
+	struct xradio_vif *priv = from_timer(priv, t, mcast_timeout);
+#else
 void xradio_mcast_timeout(unsigned long arg)
 {
 	struct xradio_vif *priv = (struct xradio_vif *)arg;
-
+#endif
 	ap_printk(XRADIO_DBG_WARN, "Multicast delivery timeout.\n");
 	spin_lock_bh(&priv->ps_state_lock);
 	priv->tx_multicast = priv->aid0_bit_set && priv->buffered_multicasts;

--- a/ap.c
+++ b/ap.c
@@ -1168,7 +1168,11 @@ static int xradio_upload_null(struct xradio_vif *priv)
 		.rate = 0xFF,
 	};
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	frame.skb = ieee80211_nullfunc_get(priv->hw, priv->vif, false);
+#else
 	frame.skb = ieee80211_nullfunc_get(priv->hw, priv->vif);
+#endif
 	if (WARN_ON(!frame.skb))
 		return -ENOMEM;
 

--- a/ap.h
+++ b/ap.h
@@ -46,7 +46,11 @@ void xradio_set_tim_work(struct work_struct *work);
 void xradio_set_cts_work(struct work_struct *work);
 void xradio_multicast_start_work(struct work_struct *work);
 void xradio_multicast_stop_work(struct work_struct *work);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+void xradio_mcast_timeout(struct timer_list *t);
+#else
 void xradio_mcast_timeout(unsigned long arg);
+#endif
 int xradio_find_link_id(struct xradio_vif *priv, const u8 *mac);
 int xradio_alloc_link_id(struct xradio_vif *priv, const u8 *mac);
 void xradio_link_id_work(struct work_struct *work);

--- a/main.c
+++ b/main.c
@@ -9,7 +9,6 @@
  * published by the Free Software Foundation.
  */
 
-
 #include <linux/firmware.h>
 #include <net/cfg80211.h>
 #include <linux/of_net.h>
@@ -357,10 +356,13 @@ struct ieee80211_hw *xradio_init_common(size_t hw_priv_data_len)
 	INIT_WORK(&hw_priv->event_handler, xradio_event_handler);
 	INIT_WORK(&hw_priv->ba_work, xradio_ba_work);
 	spin_lock_init(&hw_priv->ba_lock);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	timer_setup(&hw_priv->ba_timer, xradio_ba_timer, 0);
+#else
 	init_timer(&hw_priv->ba_timer);
 	hw_priv->ba_timer.data = (unsigned long)hw_priv;
 	hw_priv->ba_timer.function = xradio_ba_timer;
-
+#endif
 	if (unlikely(xradio_queue_stats_init(&hw_priv->tx_queue_stats,
 			WLAN_LINK_ID_MAX,xradio_skb_dtor, hw_priv))) {
 		ieee80211_free_hw(hw);

--- a/queue.c
+++ b/queue.c
@@ -156,11 +156,16 @@ static void __xradio_queue_gc(struct xradio_queue *queue,
 	}
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+static void xradio_queue_gc(struct timer_list *t)
+{
+	struct xradio_queue *queue = from_timer(queue, t, gc);
+#else
 static void xradio_queue_gc(unsigned long arg)
 {
+	struct xradio_queue *queue = (struct xradio_queue *)arg;
+#endif
 	LIST_HEAD(list);
-	struct xradio_queue *queue =
-		(struct xradio_queue *)arg;
 
 	spin_lock_bh(&queue->lock);
 	__xradio_queue_gc(queue, &list, true);
@@ -210,9 +215,13 @@ int xradio_queue_init(struct xradio_queue *queue,
 	INIT_LIST_HEAD(&queue->pending);
 	INIT_LIST_HEAD(&queue->free_pool);
 	spin_lock_init(&queue->lock);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	timer_setup(&queue->gc, xradio_queue_gc, 0);
+#else
 	init_timer(&queue->gc);
 	queue->gc.data = (unsigned long)queue;
 	queue->gc.function = xradio_queue_gc;
+#endif
 
 	queue->pool = kzalloc(sizeof(struct xradio_queue_item) * capacity,
 	                         GFP_KERNEL);

--- a/sdio.c
+++ b/sdio.c
@@ -10,6 +10,7 @@
  */
 
 #include <linux/module.h>
+#include <linux/interrupt.h>
 #include <linux/mmc/host.h>
 #include <linux/mmc/sdio_func.h>
 #include <linux/mmc/card.h>

--- a/sta.c
+++ b/sta.c
@@ -1742,10 +1742,16 @@ void xradio_ba_work(struct work_struct *work)
 	wsm_unlock_tx(hw_priv);
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+void xradio_ba_timer(struct timer_list *t)
+{
+	struct xradio_common *hw_priv = from_timer(hw_priv, t, ba_timer);
+#else
 void xradio_ba_timer(unsigned long arg)
 {
-	bool ba_ena;
 	struct xradio_common *hw_priv = (struct xradio_common *)arg;
+#endif
+	bool ba_ena;
 
 
 	spin_lock_bh(&hw_priv->ba_lock);
@@ -1827,9 +1833,13 @@ int xradio_vif_setup(struct xradio_vif *priv)
 #ifdef AP_HT_CAP_UPDATE
         INIT_WORK(&priv->ht_oper_update_work, xradio_ht_oper_update_work);
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	timer_setup(&priv->mcast_timeout, xradio_mcast_timeout, 0);
+#else
 	init_timer(&priv->mcast_timeout);
 	priv->mcast_timeout.data = (unsigned long)priv;
 	priv->mcast_timeout.function = xradio_mcast_timeout;
+#endif
 	priv->setbssparams_done = false;
 	priv->power_set_true = 0;
 	priv->user_power_set_true = 0;

--- a/sta.h
+++ b/sta.h
@@ -108,7 +108,11 @@ int xradio_enable_listening(struct xradio_vif *priv, struct ieee80211_channel *c
 int xradio_disable_listening(struct xradio_vif *priv);
 int xradio_set_uapsd_param(struct xradio_vif *priv, const struct wsm_edca_params *arg);
 void xradio_ba_work(struct work_struct *work);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+void xradio_ba_timer(struct timer_list *t);
+#else
 void xradio_ba_timer(unsigned long arg);
+#endif
 const u8 *xradio_get_ie(u8 *start, size_t len, u8 ie);
 int xradio_vif_setup(struct xradio_vif *priv);
 int xradio_setup_mac_pvif(struct xradio_vif *priv);

--- a/xradio.h
+++ b/xradio.h
@@ -12,6 +12,7 @@
 #ifndef XRADIO_H
 #define XRADIO_H
 
+#include <linux/version.h>
 #include <linux/wait.h>
 #include <linux/mutex.h>
 #include <linux/workqueue.h>


### PR DESCRIPTION
TO: @fifteenhex 
CC: @Icenowy

Hi,
Here are the fixes to build this driver for 4.14 and 4.15-rc kernels. I tested the fixes using the latest 4.15-rc6 on Orange Pi Zero board. I made use of KERNEL_VERSION macro here. I don't see a lot of usage of this macro in xradio, so let me know if it is discouraged. I will update PR accordingly.

Regards,
Sergey 