### PR TITLE
use ktime.h and getnstimeofday() for kernel >= 5

### DIFF
--- a/main.c
+++ b/main.c
@@ -364,7 +364,7 @@ struct ieee80211_hw *xradio_init_common(size_t hw_priv_data_len)
 	hw_priv->ba_timer.function = xradio_ba_timer;
 #endif
 	if (unlikely(xradio_queue_stats_init(&hw_priv->tx_queue_stats,
-			WLAN_LINK_ID_MAX,xradio_skb_dtor, hw_priv))) {
+			WLAN_LINK_ID_MAX,sizeof(int[WLAN_LINK_ID_MAX]),xradio_skb_dtor, hw_priv))) {
 		ieee80211_free_hw(hw);
 		return NULL;
 	}

--- a/queue.c
+++ b/queue.c
@@ -175,6 +175,7 @@ static void xradio_queue_gc(unsigned long arg)
 
 int xradio_queue_stats_init(struct xradio_queue_stats *stats,
 			    size_t map_capacity,
+                            size_t map_capacity_size,
 			    xradio_queue_skb_dtor_t skb_dtor,
 			    struct xradio_common *hw_priv)
 {
@@ -187,7 +188,7 @@ int xradio_queue_stats_init(struct xradio_queue_stats *stats,
 	spin_lock_init(&stats->lock);
 	init_waitqueue_head(&stats->wait_link_id_empty);
 	for (i = 0; i < XRWL_MAX_VIFS; i++) {
-		stats->link_map_cache[i] = kzalloc(sizeof(int[map_capacity]), GFP_KERNEL);
+		stats->link_map_cache[i] = kzalloc(map_capacity_size, GFP_KERNEL);
 		if (!stats->link_map_cache[i]) {
 			for (; i >= 0; i--)
 				kfree(stats->link_map_cache[i]);

--- a/queue.h
+++ b/queue.h
@@ -73,6 +73,7 @@ struct xradio_txpriv {
 
 int xradio_queue_stats_init(struct xradio_queue_stats *stats,
                             size_t map_capacity,
+                            size_t map_capacity_size,
                             xradio_queue_skb_dtor_t skb_dtor,
                             struct xradio_common *priv);
 int xradio_queue_init(struct xradio_queue *queue,

--- a/sta.c
+++ b/sta.c
@@ -31,7 +31,11 @@
 #include "net/mac80211.h"
 
 #ifdef TES_P2P_0002_ROC_RESTART
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+#include <linux/ktime.h>
+#else
 #include <linux/time.h>
+#endif
 #endif
 
 #define WEP_ENCRYPT_HDR_SIZE    4
@@ -905,15 +909,24 @@ int xradio_remain_on_channel(struct ieee80211_hw *hw,
 	int i = 0;
 	int if_id;
 #ifdef	TES_P2P_0002_ROC_RESTART
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+	struct timespec TES_P2P_0002_tmval;
+#else
 	struct timeval TES_P2P_0002_tmval;
+#endif
 #endif
 
 
 #ifdef	TES_P2P_0002_ROC_RESTART
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+	getnstimeofday(&TES_P2P_0002_tmval);
+	TES_P2P_0002_roc_usec = (s32)TES_P2P_0002_tmval.tv_nsec/1000;
+#else
 	do_gettimeofday(&TES_P2P_0002_tmval);
+	TES_P2P_0002_roc_usec = (s32)TES_P2P_0002_tmval.tv_usec;
+#endif
 	TES_P2P_0002_roc_dur  = (s32)duration;
 	TES_P2P_0002_roc_sec  = (s32)TES_P2P_0002_tmval.tv_sec;
-	TES_P2P_0002_roc_usec = (s32)TES_P2P_0002_tmval.tv_usec;
 #endif
 
 	down(&hw_priv->scan.lock);


### PR DESCRIPTION
do_gettimeofday() has been removed since https://github.com/torvalds/linux/commit/33e26418193f58d1895f2f968e1953b1caf8deb7

In theory it presumably makes sense to use getnstimeofday() regardless of kernel version, but I've limited it to kernel versions where it becomes necessary in case there's some impact I'm unaware of. You may prefer ditch the conditionals to change it globally.

I've not tested this as an installed module on a device yet (I have other problems to worry about before I get to the WiFi), but it will now compile as a module for the current sunxi-next branch without complaining about missing functions and aborting.