### PR TITLE
add ifdef's around print_hex_dump_bytes

### DIFF
--- a/bh.c
+++ b/bh.c
@@ -440,8 +440,10 @@ static void xradio_bh_rx_dump(struct device *dev, u8 *data, size_t len){
 
 	dev_dbg(dev, "vif %d: sdio rx, msgid %s(0x%.4X) len %d\n",
 			ifid, msgname, msgid, *p);
+#if defined(CONFIG_XRADIO_DEBUG)
 //	print_hex_dump_bytes("<-- ", DUMP_PREFIX_NONE,
 //	                     data, min(len, (size_t) 64));
+#endif /* CONFIG_XRADIO_DEBUG */
 #endif
 }
 

--- a/sdio.c
+++ b/sdio.c
@@ -38,7 +38,9 @@ int sdio_data_read(struct xradio_common* self, unsigned int addr,
 {
 	int ret = sdio_memcpy_fromio(self->sdio_func, dst, addr, count);
 //	printk("sdio_memcpy_fromio 0x%x:%d ret %d\n", addr, count, ret);
+#if defined(CONFIG_XRADIO_DEBUG)
 //	print_hex_dump_bytes("sdio read ", 0, dst, min(count,32));
+#endif /* CONFIG_XRADIO_DEBUG */
 	return ret;
 }
 
@@ -47,7 +49,9 @@ int sdio_data_write(struct xradio_common* self, unsigned int addr,
 {
 	int ret = sdio_memcpy_toio(self->sdio_func, addr, (void *)src, count);
 //	printk("sdio_memcpy_toio 0x%x:%d ret %d\n", addr, count, ret);
+#if defined(CONFIG_XRADIO_DEBUG)
 //	print_hex_dump_bytes("sdio write", 0, src, min(count,32));
+#endif /* CONFIG_XRADIO_DEBUG */
 	return ret;
 }
 

--- a/wsm.c
+++ b/wsm.c
@@ -2022,7 +2022,9 @@ int wsm_handle_exception(struct xradio_common *hw_priv, u8 *data, size_t len)
 
 underflow:
 	dev_err(hw_priv->pdev, "Firmware exception.\n");
+#if defined(CONFIG_XRADIO_DEBUG)
 	print_hex_dump_bytes("Exception: ", DUMP_PREFIX_NONE, data, len);
+#endif /* CONFIG_XRADIO_DEBUG */
 	return -EINVAL;
 }
 


### PR DESCRIPTION
Just a few ifdef's (even commented out ones) to handle 'symbol not found' on the resulting `.ko` when attempting to load it in some configurations (ie. no debug tracing).