### PR TITLE
fix timespec 2038 overflow in kernel >= 5

### DIFF
--- a/sta.c
+++ b/sta.c
@@ -910,7 +910,7 @@ int xradio_remain_on_channel(struct ieee80211_hw *hw,
 	int if_id;
 #ifdef	TES_P2P_0002_ROC_RESTART
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
-	struct timespec TES_P2P_0002_tmval;
+	struct timespec64 TES_P2P_0002_tmval;
 #else
 	struct timeval TES_P2P_0002_tmval;
 #endif
@@ -919,7 +919,7 @@ int xradio_remain_on_channel(struct ieee80211_hw *hw,
 
 #ifdef	TES_P2P_0002_ROC_RESTART
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
-	getnstimeofday(&TES_P2P_0002_tmval);
+	ktime_get_real_ts64(&TES_P2P_0002_tmval);
 	TES_P2P_0002_roc_usec = (s32)TES_P2P_0002_tmval.tv_nsec/1000;
 #else
 	do_gettimeofday(&TES_P2P_0002_tmval);


### PR DESCRIPTION
I previously patched this to handle deprecated time.h functions in kernels >=5.0. It turns out my fix is itself deprecated by kernel 5.6, so here we are again. :)

We're now storing TES_P2P_0002_tmval as a 64-bit value and using ktime_get_real_ts64() instead of getnstimeofday(). This fixes an overflow in 2038 and allows building against the latest kernels.

As with my previous effort, this is only happening for builds against kernel 5.0 or newer, although it should work as far back as [3.17](https://elixir.bootlin.com/linux/v3.17/ident/ktime_get_real_ts64). I didn't want to make changes beyond what I'm building and testing, so I'll leave it to you to decide if you want to apply this patch any further back.

The only practical difference between this and the existing code for older versions of the kernel is, afaik, that they'll stop working in 18 years.