### PR TITLE
sdio: remove unused mach-types.h header

### DIFF
--- a/sdio.c
+++ b/sdio.c
@@ -15,7 +15,6 @@
 #include <linux/mmc/sdio_func.h>
 #include <linux/mmc/card.h>
 #include <linux/mmc/sdio.h>
-#include <asm/mach-types.h>
 #include <linux/of.h>
 #include <linux/of_irq.h>
 


### PR DESCRIPTION
The driver does not use defines (MACH_TYPE_*) or macros (machine_is_*)
from asm/mach-types.h. Besides, this header is specific to arm, so its
removal allows build testing on other platforms.

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>