### PR TITLE
Fix multiple issues when doing insmod/rmmod and reboot

### DIFF
--- a/main.c
+++ b/main.c
@@ -613,6 +613,7 @@ err2:
 	xradio_pm_deinit(&hw_priv->pm_state);
 err1:
 	xradio_free_common(dev);
+	sdio_set_drvdata(func, NULL);
 	return err;
 }
 
@@ -625,6 +626,7 @@ void xradio_core_deinit(struct sdio_func* func)
 		xradio_unregister_bh(hw_priv);
 		xradio_pm_deinit(&hw_priv->pm_state);
 		xradio_free_common(hw_priv->hw);
+		sdio_set_drvdata(func, NULL);
 	}
 	return;
 }

--- a/sdio.c
+++ b/sdio.c
@@ -191,6 +191,7 @@ static int sdio_probe(struct sdio_func *func,
  * device is disconnected */
 static void sdio_remove(struct sdio_func *func)
 {
+	xradio_core_deinit(func);
 	sdio_claim_host(func);
 	sdio_disable_func(func);
 	sdio_release_host(func);

--- a/sdio.c
+++ b/sdio.c
@@ -184,7 +184,6 @@ static int sdio_probe(struct sdio_func *func,
 
 	xradio_core_init(func);
 
-	try_module_get(func->dev.driver->owner);
 	return 0;
 }
 /* Disconnect Function to be called by SDIO stack when
@@ -195,7 +194,6 @@ static void sdio_remove(struct sdio_func *func)
 	sdio_claim_host(func);
 	sdio_disable_func(func);
 	sdio_release_host(func);
-	module_put(func->dev.driver->owner);
 }
 
 static int sdio_suspend(struct device *dev)

--- a/sdio.c
+++ b/sdio.c
@@ -190,9 +190,11 @@ static int sdio_probe(struct sdio_func *func,
  * device is disconnected */
 static void sdio_remove(struct sdio_func *func)
 {
+	struct mmc_card *card = func->card;
 	xradio_core_deinit(func);
 	sdio_claim_host(func);
 	sdio_disable_func(func);
+	mmc_hw_reset(card->host);
 	sdio_release_host(func);
 }
 


### PR DESCRIPTION
Hi,
This patch set fixed issues observed when doing insmod/rmmod multiple times in a row and kernel crash observed during reboot. 
I have tested using orange pi zero board and kernel version 5.17.70.
Please consider pulling if you think this is useful.
Thanks and have a good one.
-- Tong
