### PR TITLE
xradio: misc fixes for new kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ modules.order
 *.ko
 *.mod
 *.mod.c
+tags

--- a/ap.c
+++ b/ap.c
@@ -467,9 +467,15 @@ void xradio_bss_info_changed(struct ieee80211_hw *dev,
 				/* TODO:COMBO:Change this once
 				* mac80211 changes are available */
 				BUG_ON(!hw_priv->channel);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 0))
+				hw_priv->ht_oper.ht_cap = sta->deflink.ht_cap;
+				priv->bss_params.operationalRateSet =__cpu_to_le32(
+				  xradio_rate_mask_to_wsm(hw_priv, sta->deflink.supp_rates[hw_priv->channel->band]));
+#else
 				hw_priv->ht_oper.ht_cap = sta->ht_cap;
 				priv->bss_params.operationalRateSet =__cpu_to_le32(
 				  xradio_rate_mask_to_wsm(hw_priv, sta->supp_rates[hw_priv->channel->band]));
+#endif
 				/* TODO by Icenowy: I think this may lead to some problems. */
 //				hw_priv->ht_oper.channel_type   = info->channel_type;
 				hw_priv->ht_oper.operation_mode = info->ht_operation_mode;

--- a/ap.h
+++ b/ap.h
@@ -29,10 +29,17 @@ int xradio_sta_remove(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 void xradio_sta_notify(struct ieee80211_hw *dev, struct ieee80211_vif *vif,
 		       enum sta_notify_cmd notify_cmd,
 		       struct ieee80211_sta *sta);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+void xradio_bss_info_changed(struct ieee80211_hw *dev,
+			     struct ieee80211_vif *vif,
+			     struct ieee80211_bss_conf *info,
+			     u64 changed);
+#else
 void xradio_bss_info_changed(struct ieee80211_hw *dev,
 			     struct ieee80211_vif *vif,
 			     struct ieee80211_bss_conf *info,
 			     u32 changed);
+#endif
 int xradio_ampdu_action(struct ieee80211_hw *hw,
 			struct ieee80211_vif *vif,
 			struct ieee80211_ampdu_params *params);

--- a/bh.c
+++ b/bh.c
@@ -326,11 +326,11 @@ static struct sk_buff *xradio_get_skb(struct xradio_common *hw_priv, size_t len)
 		} else {
 			skb = xradio_get_resv_skb(hw_priv, alloc_len);
 			if (skb) {
-				dev_dbg(hw_priv->pdev, "get skb_reserved(%d)!\n", alloc_len);
+				dev_dbg(hw_priv->pdev, "get skb_reserved(%zu)!\n", alloc_len);
 				skb_reserve(skb, WSM_TX_EXTRA_HEADROOM + 8 /* TKIP IV */
 						    - WSM_RX_EXTRA_HEADROOM);
 			} else {
-				dev_dbg(hw_priv->pdev, "xr_alloc_skb failed(%d)!\n", alloc_len);
+				dev_dbg(hw_priv->pdev, "xr_alloc_skb failed(%zu)!\n", alloc_len);
 			}
 		}
 	} else {
@@ -473,7 +473,7 @@ static int xradio_bh_rx(struct xradio_common *hw_priv, u16* nextlen) {
 		return read_len;
 
 	if (read_len < sizeof(struct wsm_hdr) || (read_len > EFFECTIVE_BUF_SIZE)) {
-		dev_err(hw_priv->pdev, "Invalid read len: %d", read_len);
+		dev_err(hw_priv->pdev, "Invalid read len: %zu", read_len);
 		return -1;
 	}
 
@@ -484,7 +484,7 @@ static int xradio_bh_rx(struct xradio_common *hw_priv, u16* nextlen) {
 	alloc_len = sdio_align_len(hw_priv, read_len);
 	/* Check if not exceeding XRADIO capabilities */
 	if (WARN_ON_ONCE(alloc_len > EFFECTIVE_BUF_SIZE)) {
-		dev_err(hw_priv->pdev, "Read aligned len: %d\n", alloc_len);
+		dev_err(hw_priv->pdev, "Read aligned len: %zu\n", alloc_len);
 	}
 
 	/* Get skb buffer. */
@@ -520,7 +520,7 @@ static int xradio_bh_rx(struct xradio_common *hw_priv, u16* nextlen) {
 	wsm_len = __le32_to_cpu(wsm->len);
 
 	if (WARN_ON(wsm_len > read_len)) {
-		dev_err(hw_priv->pdev, "wsm is bigger than data read, read %d but frame is %d\n",
+		dev_err(hw_priv->pdev, "wsm is bigger than data read, read %zu but frame is %zu\n",
 				read_len, wsm_len);
 		ret = -1;
 		goto out;
@@ -689,7 +689,7 @@ static int xradio_bh_tx(struct xradio_common *hw_priv){
 
 			/* Check if not exceeding XRADIO capabilities */
 			if (tx_len > EFFECTIVE_BUF_SIZE) {
-				dev_warn(hw_priv->pdev, "Write aligned len: %d\n", tx_len);
+				dev_warn(hw_priv->pdev, "Write aligned len: %zu\n", tx_len);
 			}
 
 			/* Make sequence number. */

--- a/fwio.c
+++ b/fwio.c
@@ -172,7 +172,7 @@ static int xradio_parse_sdd(struct xradio_common *hw_priv, u32 *dpll)
 		pElement = FIND_NEXT_ELT(pElement);
 	}
 	
-	dev_dbg(hw_priv->pdev, "sdd size=%d parse len=%d.\n",
+	dev_dbg(hw_priv->pdev, "sdd size=%zu parse len=%d.\n",
 	           hw_priv->sdd->size, parsedLength);
 
 	//

--- a/keys.c
+++ b/keys.c
@@ -65,13 +65,15 @@ int xradio_set_key(struct ieee80211_hw *dev, enum set_key_cmd cmd,
 		u8 *peer_addr = NULL;
 		int pairwise = (key->flags & IEEE80211_KEY_FLAG_PAIRWISE) ? 1 : 0;
 		int idx = xradio_alloc_key(hw_priv);
-		struct wsm_add_key *wsm_key = &hw_priv->keys[idx];
+		struct wsm_add_key *wsm_key;
 
 		if (idx < 0) {
 			wiphy_err(dev->wiphy, "xradio_alloc_key failed!\n");
 			ret = -EINVAL;
 			goto finally;
 		}
+
+		wsm_key = &hw_priv->keys[idx];
 
 		BUG_ON(pairwise && !sta);
 		if (sta)

--- a/scan.c
+++ b/scan.c
@@ -887,7 +887,7 @@ void xradio_probe_work(struct work_struct *work)
 	if (!ret)
 		IEEE80211_SKB_CB(frame.skb)->flags |= IEEE80211_TX_STAT_ACK;
 
-		BUG_ON(xradio_queue_remove(queue, hw_priv->pending_frame_id));
+	BUG_ON(xradio_queue_remove(queue, hw_priv->pending_frame_id));
 
 	if (ret) {
 		hw_priv->scan.direct_probe = 0;

--- a/sdio.c
+++ b/sdio.c
@@ -194,7 +194,11 @@ static void sdio_remove(struct sdio_func *func)
 	xradio_core_deinit(func);
 	sdio_claim_host(func);
 	sdio_disable_func(func);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+	mmc_hw_reset(card);
+#else
 	mmc_hw_reset(card->host);
+#endif
 	sdio_release_host(func);
 }
 

--- a/sta.c
+++ b/sta.c
@@ -663,8 +663,14 @@ void xradio_configure_filter(struct ieee80211_hw *hw,
 	}
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+int xradio_conf_tx(struct ieee80211_hw *dev, struct ieee80211_vif *vif,
+                   unsigned int link_id, u16 queue,
+		   const struct ieee80211_tx_queue_params *params)
+#else
 int xradio_conf_tx(struct ieee80211_hw *dev, struct ieee80211_vif *vif,
                    u16 queue, const struct ieee80211_tx_queue_params *params)
+#endif
 {
 	struct xradio_common *hw_priv = dev->priv;
 	struct xradio_vif *priv = xrwl_get_vif_from_ieee80211(vif);

--- a/sta.h
+++ b/sta.h
@@ -47,8 +47,14 @@ void xradio_configure_filter(struct ieee80211_hw *dev,
                              unsigned int changed_flags,
                              unsigned int *total_flags,
                              u64 multicast);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+int xradio_conf_tx(struct ieee80211_hw *dev, struct ieee80211_vif *vif,
+                   unsigned int link_id, u16 queue,
+		   const struct ieee80211_tx_queue_params *params);
+#else
 int xradio_conf_tx(struct ieee80211_hw *dev, struct ieee80211_vif *vif,
                    u16 queue, const struct ieee80211_tx_queue_params *params);
+#endif
 int xradio_get_stats(struct ieee80211_hw *dev,
                      struct ieee80211_low_level_stats *stats);
 /* Not more a part of interface?

--- a/tx.c
+++ b/tx.c
@@ -559,7 +559,7 @@ xradio_tx_h_crypt(struct xradio_vif *priv,
 		dev_dbg(priv->hw_priv->pdev,
 			"no space allocated for crypto headers.\n"
 			"headroom: %d, tailroom: %d, "
-			"req_headroom: %d, req_tailroom: %d\n"
+			"req_headroom: %zu, req_tailroom: %zu\n"
 			"Please fix it in xradio_get_skb().\n",
 			skb_headroom(t->skb), skb_tailroom(t->skb),
 			iv_len + WSM_TX_EXTRA_HEADROOM, icv_len);
@@ -569,7 +569,7 @@ xradio_tx_h_crypt(struct xradio_vif *priv,
 		u8 *p;
 		dev_dbg(priv->hw_priv->pdev,
 			"Slowpath: tailroom is not big enough. "
-			"Req: %d, got: %d.\n",
+			"Req: %zu, got: %d.\n",
 			icv_len, skb_tailroom(t->skb));
 
 		p = skb_push(t->skb, offset);

--- a/wsm.c
+++ b/wsm.c
@@ -1773,7 +1773,7 @@ int wsm_cmd_send(struct xradio_common *hw_priv,
 		hw_priv->wsm_cmd.ptr = NULL;
 		spin_unlock(&hw_priv->wsm_cmd.lock);
 
-		dev_err(hw_priv->pdev, "***CMD timeout!>>> 0x%.4X (%d), buf_use=%d, bh_state=%d\n",
+		dev_err(hw_priv->pdev, "***CMD timeout!>>> 0x%.4X (%zu), buf_use=%d, bh_state=%d\n",
 			   cmd, buf_len, hw_priv->hw_bufs_used, hw_priv->bh_error);
 		/* Race condition check to make sure _confirm is not called
 		 * after exit of _send */
@@ -2002,7 +2002,7 @@ int wsm_handle_exception(struct xradio_common *hw_priv, u8 *data, size_t len)
 		           reason_str[reason]);
 	} else {
 		dev_err(hw_priv->pdev, "Firmware assert at %.*s, line %d, reason=0x%x\n",
-			       sizeof(fname), fname, reg[1], reg[2]);
+			       (int) sizeof(fname), fname, reg[1], reg[2]);
 	}
 
 	for (i = 0; i < 12; i += 4) {


### PR DESCRIPTION
Introduce several changes required to build xradio with kernels v5.18, v5.19, v6.0.