### PR TITLE
sdio: use sdio_readl for u32 values on stack

### DIFF
--- a/fwio.c
+++ b/fwio.c
@@ -70,7 +70,7 @@ static int xradio_get_hw_type(u32 config_reg_val, int *major_revision)
 	//u32 hif_vers = (config_reg_val >> 31) & 0x1;
 
 	/* Check if we have XRADIO*/
-  if (hif_type == 0x4) {
+	if (hif_type == 0x4) {
 		*major_revision = 0x4;
 		hw_type = HIF_HW_TYPE_XRADIO;
 	} else {

--- a/sdio.c
+++ b/sdio.c
@@ -35,22 +35,34 @@ static const struct sdio_device_id xradio_sdio_ids[] = {
 int sdio_data_read(struct xradio_common* self, unsigned int addr,
                           void *dst, int count)
 {
-	int ret = sdio_memcpy_fromio(self->sdio_func, dst, addr, count);
-//	printk("sdio_memcpy_fromio 0x%x:%d ret %d\n", addr, count, ret);
-#if defined(CONFIG_XRADIO_DEBUG)
-//	print_hex_dump_bytes("sdio read ", 0, dst, min(count,32));
-#endif /* CONFIG_XRADIO_DEBUG */
+	int ret;
+
+	switch (count) {
+	case 4:
+		*((u32 *)dst) = sdio_readl(self->sdio_func, addr, &ret);
+		break;
+	default:
+		ret = sdio_memcpy_fromio(self->sdio_func, dst, addr, count);
+		break;
+	}
+
 	return ret;
 }
 
 int sdio_data_write(struct xradio_common* self, unsigned int addr,
                            const void *src, int count)
 {
-	int ret = sdio_memcpy_toio(self->sdio_func, addr, (void *)src, count);
-//	printk("sdio_memcpy_toio 0x%x:%d ret %d\n", addr, count, ret);
-#if defined(CONFIG_XRADIO_DEBUG)
-//	print_hex_dump_bytes("sdio write", 0, src, min(count,32));
-#endif /* CONFIG_XRADIO_DEBUG */
+	int ret;
+
+	switch (count) {
+	case 4:
+		sdio_writel(self->sdio_func, *((u32 *)src), addr, &ret);
+		break;
+	default:
+		ret = sdio_memcpy_toio(self->sdio_func, addr, (void *)src, count);
+		break;
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
With introduction of vmap'ed stacks, stack parameters can no longer be used for DMA. Using stack buffers may lead to invalid data exchange with device or even to kernel panics.

For xradio all u32 parameters in register operations are allocated on stack and all larger data buffers are dynamically allocated. This patch switches all u32 register operations to sdio_readl which uses properly allocated temporary buffer internally.

Tested on v5.17, v5.18 and v6.1 with OrangePi Zero.

Fixes: a1c510d0adc6 ("ARM: implement support for vmap'ed stacks")
Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>