### PR TITLE
fix driver for Kernel version 6.9+

### DIFF
--- a/main.c
+++ b/main.c
@@ -165,7 +165,13 @@ static const struct ieee80211_ops xradio_ops = {
 	.cancel_remain_on_channel = xradio_cancel_remain_on_channel,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))
 	.wake_tx_queue		= ieee80211_handle_wake_tx_queue,
-#endif 	
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
+       .add_chanctx = ieee80211_emulate_add_chanctx,
+       .remove_chanctx = ieee80211_emulate_remove_chanctx,
+       .change_chanctx = ieee80211_emulate_change_chanctx,
+       .switch_vif_chanctx = ieee80211_emulate_switch_vif_chanctx,
+#endif
 };
 
 


### PR DESCRIPTION
Hi there!
I just tried to use this patch on my Arch powered OrangePI Zero, with no luck. It has stopped with the following error:
```
[   14.407020] ------------[ cut here ]------------
[   14.411731] WARNING: CPU: 1 PID: 239 at net/mac80211/main.c:801 ieee80211_alloc_hw_nm+0x640/0x724 [mac80211]
[   14.422295] Modules linked in: xradio_wlan(O+) mac80211 dwmac_sun8i sun4i_spdif sun8i_codec_analog stmmac_platform sun8i_adda_pr_regmap snd_soc_core stmmac pcs_xpcs phyli
nk ac97_bus snd_pcm_dmaengine mdio_mux snd_pcm libarc4 spi_sun6i snd_timer lima sunxi_wdt sun8i_ce sun4i_tcon sun8i_mixer sun8i_tcon_top drm_dma_helper cfg80211 rfkill uio_p
drv_genirq uio sch_fq_codel fuse dm_mod nfnetlink ip_tables x_tables
[   14.458741] CPU: 1 PID: 239 Comm: (udev-worker) Tainted: G           O       6.9.12-1-ARCH #1
[   14.458765] Hardware name: Allwinner sun8i Family
[   14.458773] Call trace: 
[   14.458789]  unwind_backtrace from show_stack+0x10/0x14
[   14.458832]  show_stack from dump_stack_lvl+0x50/0x64
[   14.458858]  dump_stack_lvl from __warn+0x94/0xc0
[   14.458884]  __warn from warn_slowpath_fmt+0x160/0x1ec
[   14.458909]  warn_slowpath_fmt from ieee80211_alloc_hw_nm+0x640/0x724 [mac80211]
[   14.459490]  ieee80211_alloc_hw_nm [mac80211] from xradio_init_common+0x18/0x6d8 [xradio_wlan]
[   14.459925]  xradio_init_common [xradio_wlan] from xradio_core_init+0x24/0x3cc [xradio_wlan]
[   14.460050]  xradio_core_init [xradio_wlan] from sdio_probe+0xf8/0x138 [xradio_wlan]
[   14.460170]  sdio_probe [xradio_wlan] from sdio_bus_probe+0xd8/0x180
[   14.460254]  sdio_bus_probe from really_probe+0xc8/0x2c8
[   14.460286]  really_probe from __driver_probe_device+0x88/0x1a0
[   14.460307]  __driver_probe_device from driver_probe_device+0x30/0x110
[   14.460326]  driver_probe_device from __driver_attach+0x90/0x178
[   14.460345]  __driver_attach from bus_for_each_dev+0x70/0xc4
[   14.460364]  bus_for_each_dev from bus_add_driver+0xcc/0x1ec
[   14.460382]  bus_add_driver from driver_register+0x80/0x11c
[   14.460402]  driver_register from do_one_initcall+0x48/0x270
[   14.460426]  do_one_initcall from do_init_module+0x54/0x1dc
[   14.460448]  do_init_module from sys_init_module+0x1e0/0x214
[   14.460465]  sys_init_module from __sys_trace_return+0x0/0x10
[   14.460482] Exception stack(0xe0a41fa8 to 0xe0a41ff0)
[   14.460496] 1fa0:                   009c5db8 b487c008 b487c008 00026f60 b5809864 00000000
[   14.460509] 1fc0: 009c5db8 b487c008 b5809864 00000080 009c4038 009c56e8 009c30d8 b6e5ad00
[   14.460519] 1fe0: b580bf1c be9645c0 b5800154 b69f69d0
[   14.460599] ---[ end trace 0000000000000000 ]---
```
Now it seems to be working fine:
```
$ uname -a
Linux archOrangePiZeroLTS 6.9.12-1-ARCH #1 SMP PREEMPT Sat Jul 27 18:56:02 MDT 2024 armv7l GNU/Linux
$ cat /sys/firmware/devicetree/base/model
Xunlong Orange Pi Zero
$ modinfo xradio_wlan
filename:       /lib/modules/6.9.12-1-ARCH/updates/xradio_wlan.ko.gz
alias:          xradio_core
license:        GPL
description:    XRadioTech WLAN driver core
author:         XRadioTech
alias:          sdio:c*v0020d2281*
depends:        mac80211,cfg80211
name:           xradio_wlan
vermagic:       6.9.12-1-ARCH SMP preempt mod_unload modversions ARMv7 p2v8
$ dmesg | grep xradio
[   14.442958] xradio_wlan: loading out-of-tree module taints kernel.
[   14.822479] xradio_wlan mmc1:0001:1: missed interrupt
[   14.828262] xradio_wlan mmc1:0001:1:    Input buffers: 30 x 1632 bytes
[   14.845737] xradio_wlan mmc1:0001:1: Firmware Label:XR_C01.08.52.58 Jul 19 2018 18:53:57
$ ip a show wlan0
3: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
    inet x.x.x.x/24 brd x.x.x.x scope global dynamic noprefixroute wlan0
       valid_lft 86388sec preferred_lft 75588sec
    inet6 xxxx::xxxx:xxxx:xxxx:xxxx/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
```