### PR TITLE
Fix for kernel 6.11

### DIFF
--- a/sta.c
+++ b/sta.c
@@ -117,7 +117,7 @@ out:
 	return ret;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
 void xradio_stop(struct ieee80211_hw *dev, bool suspend)
 #else
 void xradio_stop(struct ieee80211_hw *dev)

--- a/sta.h
+++ b/sta.h
@@ -31,7 +31,7 @@
 /* mac80211 API								*/
 
 int xradio_start(struct ieee80211_hw *dev);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
 void xradio_stop(struct ieee80211_hw *dev, bool suspend);
 #else
 void xradio_stop(struct ieee80211_hw *dev);


### PR DESCRIPTION
The kernel that armbian build generates for kernel version 6.11 needs the suspend flag as well. Otherwise an incompatible-pointer-types error is thrown.

