### PR TITLE
Fix build with Linux 6.15

### DIFF
--- a/xradio.h
+++ b/xradio.h
@@ -47,6 +47,13 @@
 #include "pm.h"
 #include "fwio.h"
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
+static inline int del_timer_sync(struct timer_list *timer)
+{
+	return timer_delete_sync(timer);
+}
+#endif
+
 /* #define ROC_DEBUG */
 /* hidden ssid is only supported when separate probe resp IE
    configuration is supported */


### PR DESCRIPTION
Commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8fa7292fee5c5240402371ea89 ab285ec856c916
drops del_timer_sync() in favor of timer_delete_sync() so let's backport locally functions del_timer_sync() when Linux version is 6.15.0 or later.