### PR TITLE
Fix build for kernel 6.17

### DIFF
--- a/sta.c
+++ b/sta.c
@@ -381,7 +381,11 @@ int xradio_change_interface(struct ieee80211_hw *dev,
 	return ret;
 }
 
-int xradio_config(struct ieee80211_hw *dev, u32 changed)
+int xradio_config(struct ieee80211_hw *dev,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
+		  int radio_idx,
+#endif
+		  u32 changed)
 {
 	int ret = 0;
 	struct xradio_common *hw_priv = dev->priv;
@@ -796,7 +800,11 @@ void xradio_wep_key_work(struct work_struct *work)
 	wsm_unlock_tx(hw_priv);
 }
 
-int xradio_set_rts_threshold(struct ieee80211_hw *hw, u32 value)
+int xradio_set_rts_threshold(struct ieee80211_hw *hw,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
+			     int radio_idx,
+#endif
+			     u32 value)
 {
 	struct xradio_common *hw_priv = hw->priv;
 	int ret = 0;

--- a/sta.h
+++ b/sta.h
@@ -42,7 +42,11 @@ int xradio_change_interface(struct ieee80211_hw *dev,
                             struct ieee80211_vif *vif,
                             enum nl80211_iftype new_type,
                             bool p2p);
-int xradio_config(struct ieee80211_hw *dev, u32 changed);
+int xradio_config(struct ieee80211_hw *dev,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
+		  int radio_idx,
+#endif
+		  u32 changed);
 int xradio_change_interface(struct ieee80211_hw *dev,
                             struct ieee80211_vif *vif,
                             enum nl80211_iftype new_type,
@@ -65,7 +69,11 @@ int xradio_get_stats(struct ieee80211_hw *dev,
 int xradio_get_tx_stats(struct ieee80211_hw *dev,
 			struct ieee80211_tx_queue_stats *stats);
 */
-int xradio_set_rts_threshold(struct ieee80211_hw *hw, u32 value);
+int xradio_set_rts_threshold(struct ieee80211_hw *hw,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
+			     int radio_idx,
+#endif
+			     u32 value);
 
 void xradio_flush(struct ieee80211_hw *hw, struct ieee80211_vif *vif, u32 queues, bool drop);
 


### PR DESCRIPTION
With commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=b74947b4f6ff7c122a1bb6eb38bb7ecfbb1d3820 set_rts_threshold() and config() gain argument radio_idx to get radio index. So let's add that argument according to Linux version >= 6.17.